### PR TITLE
Add missing kb_config.py module (v3.0 fix)

### DIFF
--- a/tools/kb_config.py
+++ b/tools/kb_config.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+kb_config - Knowledge Base Configuration
+
+Provides KBConfig class for configuration management.
+Extracted from kb.py for v3.0 modularity.
+
+Author: Knowledge Base Curator
+Version: 1.0.0
+License: MIT
+"""
+
+import yaml
+from pathlib import Path
+from typing import Optional
+
+
+class KBConfig:
+    """Knowledge base configuration."""
+
+    def __init__(self, project_root: Optional[Path] = None):
+        self.project_root = project_root or Path.cwd()
+
+        # Smart detection: check if we're in shared-knowledge-base repository
+        # (has entries in root directory vs docs/knowledge-base structure)
+        self.kb_dir = self._detect_kb_dir()
+        self.kb_root = self.kb_dir  # Alias for compatibility
+        self.cache_root = self.kb_dir / ".cache"  # Alias for compatibility
+        self.shared_dir = self.kb_dir / "shared"
+        self.cache_dir = self.kb_dir / ".cache"
+        self.index_db = self.cache_dir / "kb_index.db"
+
+        # Create cache directory if needed
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _detect_kb_dir(self) -> Path:
+        """Detect KB directory - handles both standard and shared-kb-repo layouts."""
+        cwd = self.project_root
+
+        # Check for shared-knowledge-base repository layout (entries in root)
+        # Look for errors/ or patterns/ directories anywhere in the tree
+        has_kb_structure = any(
+            d.is_dir() and d.name in ['errors', 'patterns']
+            for d in cwd.rglob('*')
+            if '.git' not in str(d) and '__pycache__' not in str(d) and '.cache' not in str(d)
+        )
+
+        if has_kb_structure:
+            # This is the shared-knowledge-base repository itself
+            return cwd
+
+        # Standard project layout: docs/knowledge-base
+        standard_kb = cwd / "docs" / "knowledge-base"
+        if standard_kb.exists():
+            return standard_kb
+
+        # Fallback to docs/knowledge-base
+        return cwd / "docs" / "knowledge-base"
+
+    @classmethod
+    def from_file(cls, config_path: Path) -> 'KBConfig':
+        """Load configuration from YAML file."""
+        with config_path.open() as f:
+            config_data = yaml.safe_load(f)
+
+        instance = cls()
+        # Override defaults with config file values
+        for key, value in config_data.items():
+            if hasattr(instance, key):
+                setattr(instance, key, Path(value) if 'dir' in key else value)
+
+        return instance


### PR DESCRIPTION
Problem:
All v3.0 tools (kb_predictive, kb_patterns, kb_community, kb_freshness) were failing with "ModuleNotFoundError: No module named 'kb_config'"

Root Cause:
- v3.0 documentation referenced kb_config module
- Module was not included in repository
- KBConfig class only existed in kb.py

Solution:
- Extract KBConfig class from kb.py into standalone module
- Add compatibility aliases (kb_root, cache_root) for tool compatibility
- Enable all v3.0 advanced features to work

Files Changed:
- tools/kb_config.py (new, 68 lines)

Testing:
✅ kb_versions.py: Working
✅ kb_predictive.py: Working
✅ kb_patterns.py: Working
✅ kb_community.py: Working
✅ kb_freshness.py: Working

Impact:
- Fixes critical blocker for all v3.0 features
- Required for: version monitoring, predictive analytics, pattern recognition, community analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)